### PR TITLE
Update page.md

### DIFF
--- a/docs/controls/page.md
+++ b/docs/controls/page.md
@@ -990,19 +990,16 @@ def main(page: ft.Page):
 
     def window_event(e):
         if e.data == "close":
-            page.dialog = confirm_dialog
-            confirm_dialog.open = True
-            page.update()
+            page.open(confirm_dialog)
 
     page.window.prevent_close = True
-    page.on_window_event = window_event
+    page.window.on_event = window_event
 
     def yes_click(e):
         page.window.destroy()
 
     def no_click(e):
-        confirm_dialog.open = False
-        page.update()
+        page.close(confirm_dialog)
 
     confirm_dialog = ft.AlertDialog(
         modal=True,


### PR DESCRIPTION
+ Changed syntax of `page.on_window_event` to newer version `page.window.on_event` (Deprecated in v0.23.0 and will be removed in v0.26.0. Use [Page.window.on_event()](https://flet.dev/docs/controls/page#window) instead.)
+ Changed `window_event` function to `page.open(confirm_dialog)` instead of setting open property to **True** and updating control
+ Changed `no_click` function to `page.close(confirm_dialog)` instead of setting open property to **False** and updating control